### PR TITLE
Refactor code for 'server show', 'server create' output

### DIFF
--- a/lib/chef/knife/oci_helper.rb
+++ b/lib/chef/knife/oci_helper.rb
@@ -173,36 +173,6 @@ class Chef
       else
         return response
       end
-
-      def show_value(key, value, color = :cyan)
-        ui.msg "#{ui.color(key, color)}: #{value}" if value && !value.to_s.empty?
-      end
-
-      # rubocop:disable Metrics/CyclomaticComplexity
-      def display_server_info(config, instance, vnics)
-        show_value('Display Name', instance.display_name)
-        show_value('Instance ID', instance.id)
-        show_value('Lifecycle State', instance.lifecycle_state)
-        show_value('Availability Domain', instance.availability_domain)
-        show_value('Compartment Name', instance.compartment_name) if instance.respond_to? :compartment_name
-        show_value('Compartment ID', instance.compartment_id)
-        show_value('Region', instance.region)
-        show_value('Image Name', instance.image_name) if instance.respond_to? :image_name
-        show_value('Image ID', instance.image_id)
-        show_value('Shape', instance.shape)
-        show_value('VCN Name', instance.vcn_name) if instance.respond_to? :vcn_name
-        show_value('VCN ID', instance.vcn_id) if instance.respond_to? :vcn_id
-        show_value('Launched', instance.launchtime) if instance.respond_to? :launchtime
-        vnics.each_index do |index|
-          prefix = vnics[index].is_primary ? 'Primary' : 'Secondary'
-          show_value("#{prefix} Public IP Address", vnics[index].public_ip)
-          show_value("#{prefix} Private IP Address", vnics[index].private_ip)
-          show_value("#{prefix} Hostname", vnics[index].hostname_label)
-          show_value("#{prefix} FQDN", vnics[index].fqdn) if vnics[index].respond_to? :fqdn
-          show_value("#{prefix} Subnet Name", vnics[index].subnet_name) if vnics[index].respond_to? :subnet_name
-        end
-        show_value('Node Name', config[:chef_node_name])
-      end
     end
   end
 end

--- a/lib/chef/knife/oci_helper_show.rb
+++ b/lib/chef/knife/oci_helper_show.rb
@@ -1,0 +1,78 @@
+# Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+
+require 'chef/knife'
+require 'knife-oci/version'
+
+# Methods to extend the instance model
+module ServerDetails
+  attr_accessor :compartment_name
+  attr_accessor :image_name
+  attr_accessor :launchtime
+  attr_accessor :vcn_id
+  attr_accessor :vcn_name
+end
+
+# Methods to extend the vnic model
+module VnicDetails
+  attr_accessor :fqdn
+  attr_accessor :subnet_name
+  attr_accessor :vcn_id
+end
+
+class Chef
+  class Knife
+    # Utility routines to fill out data for 'server show' functionality
+    module OciHelperShow
+      def lookup_compartment_name(compartment_id)
+        compartment = identity_client.get_compartment(compartment_id, {})
+      rescue OCI::Errors::ServiceError => service_error
+        raise unless service_error.service_code == 'NotAuthorizedOrNotFound'
+      else
+        compartment.data.name
+      end
+
+      def lookup_image_name(image_id)
+        image = compute_client.get_image(image_id, {})
+      rescue OCI::Errors::ServiceError => service_error
+        raise unless service_error.service_code == 'NotAuthorizedOrNotFound'
+      else
+        image.data.display_name
+      end
+
+      def lookup_vcn_name(vcn_id)
+        vcn = network_client.get_vcn(vcn_id, {})
+      rescue OCI::Errors::ServiceError => service_error
+        raise unless service_error.service_code == 'NotAuthorizedOrNotFound'
+      else
+        vcn.data.display_name
+      end
+
+      def add_server_details(server, vcn_id)
+        server.extend ServerDetails
+
+        server.launchtime = server.time_created.strftime('%a, %e %b %Y %T %Z')
+        server.compartment_name = lookup_compartment_name(server.compartment_id)
+        server.image_name = lookup_image_name(server.image_id)
+        server.vcn_id = vcn_id
+        server.vcn_name = lookup_vcn_name(vcn_id)
+      end
+
+      def add_vnic_details(vnic)
+        vnic.extend VnicDetails
+
+        begin
+          subnet = network_client.get_subnet(vnic.subnet_id, {})
+        rescue OCI::Errors::ServiceError => service_error
+          raise unless service_error.service_code == 'NotAuthorizedOrNotFound'
+        else
+          vnic.fqdn = vnic.hostname_label + '.' + subnet.data.subnet_domain_name if
+            subnet.data && subnet.data.subnet_domain_name && vnic.hostname_label
+          vnic.subnet_name = subnet.data.display_name if
+            subnet.data && subnet.data.display_name
+          # piggyback the vcn_id from here, so we can avoid a few network calls
+          vnic.vcn_id = subnet.data.vcn_id
+        end
+      end
+    end
+  end
+end

--- a/lib/chef/knife/oci_helper_show.rb
+++ b/lib/chef/knife/oci_helper_show.rb
@@ -73,6 +73,36 @@ class Chef
           vnic.vcn_id = subnet.data.vcn_id
         end
       end
+
+      def show_value(key, value, color = :cyan)
+        ui.msg "#{ui.color(key, color)}: #{value}" if value && !value.to_s.empty?
+      end
+
+      # rubocop:disable Metrics/CyclomaticComplexity
+      def display_server_info(config, instance, vnics)
+        show_value('Display Name', instance.display_name)
+        show_value('Instance ID', instance.id)
+        show_value('Lifecycle State', instance.lifecycle_state)
+        show_value('Availability Domain', instance.availability_domain)
+        show_value('Compartment Name', instance.compartment_name) if instance.respond_to? :compartment_name
+        show_value('Compartment ID', instance.compartment_id)
+        show_value('Region', instance.region)
+        show_value('Image Name', instance.image_name) if instance.respond_to? :image_name
+        show_value('Image ID', instance.image_id)
+        show_value('Shape', instance.shape)
+        show_value('VCN Name', instance.vcn_name) if instance.respond_to? :vcn_name
+        show_value('VCN ID', instance.vcn_id) if instance.respond_to? :vcn_id
+        show_value('Launched', instance.launchtime) if instance.respond_to? :launchtime
+        vnics.each_index do |index|
+          prefix = vnics[index].is_primary ? 'Primary' : 'Secondary'
+          show_value("#{prefix} Public IP Address", vnics[index].public_ip)
+          show_value("#{prefix} Private IP Address", vnics[index].private_ip)
+          show_value("#{prefix} Hostname", vnics[index].hostname_label)
+          show_value("#{prefix} FQDN", vnics[index].fqdn) if vnics[index].respond_to? :fqdn
+          show_value("#{prefix} Subnet Name", vnics[index].subnet_name) if vnics[index].respond_to? :subnet_name
+        end
+        show_value('Node Name', config[:chef_node_name])
+      end
     end
   end
 end

--- a/lib/chef/knife/oci_server_create.rb
+++ b/lib/chef/knife/oci_server_create.rb
@@ -2,6 +2,7 @@
 
 require 'chef/knife'
 require 'chef/knife/oci_helper'
+require 'chef/knife/oci_helper_show'
 require 'chef/knife/oci_common_options'
 
 class Chef
@@ -11,6 +12,7 @@ class Chef
       banner 'knife oci server create (options)'
 
       include OciHelper
+      include OciHelperShow
       include OciCommonOptions
 
       # Port for SSH - might want to parameterize this in the future.

--- a/lib/chef/knife/oci_server_create.rb
+++ b/lib/chef/knife/oci_server_create.rb
@@ -137,21 +137,10 @@ class Chef
         instance = response.data
 
         ui.msg "Launched instance '#{instance.display_name}' [#{instance.id}]"
-        show_value('Display Name', instance.display_name)
-        show_value('Instance ID', instance.id)
-        show_value('Availability Domain', instance.availability_domain)
-        show_value('Compartment ID', instance.compartment_id)
-        show_value('Region', instance.region)
-        show_value('Image ID', instance.image_id)
-        show_value('Shape', instance.shape)
-
         instance = wait_for_instance_running(instance.id)
-
         ui.msg "Instance '#{instance.display_name}' is now running."
 
         vnic = get_vnic(instance.id, instance.compartment_id)
-        show_value('Public IP Address', vnic.public_ip)
-        show_value('Private IP Address', vnic.private_ip)
 
         unless wait_for_ssh(vnic.public_ip, SSH_PORT, WAIT_FOR_SSH_INTERVAL_SECONDS, config[:wait_for_ssh_max])
           error_and_exit 'Timed out while waiting for SSH access.'
@@ -168,6 +157,9 @@ class Chef
 
         ui.msg "Created and bootstrapped node '#{config[:chef_node_name]}'."
         ui.msg "\n"
+
+        add_vnic_details(vnic)
+        add_server_details(instance, vnic.vcn_id)
 
         display_server_info(config, instance, [vnic])
       end

--- a/lib/chef/knife/oci_server_show.rb
+++ b/lib/chef/knife/oci_server_show.rb
@@ -3,22 +3,7 @@
 require 'chef/knife'
 require 'chef/knife/oci_common_options'
 require 'chef/knife/oci_helper'
-
-# Methods to extend the instance model
-module ServerDetails
-  attr_accessor :compartment_name
-  attr_accessor :image_name
-  attr_accessor :launchtime
-  attr_accessor :vcn_id
-  attr_accessor :vcn_name
-end
-
-# Methods to extend the vnic model
-module VnicDetails
-  attr_accessor :fqdn
-  attr_accessor :subnet_name
-  attr_accessor :vcn_id
-end
+require 'chef/knife/oci_helper_show'
 
 class Chef
   class Knife
@@ -28,6 +13,7 @@ class Chef
       banner 'knife oci server show (options)'
 
       include OciHelper
+      include OciHelperShow
       include OciCommonOptions
 
       deps do
@@ -37,57 +23,6 @@ class Chef
       option :instance_id,
              long: '--instance_id LIMIT',
              description: 'The OCID of the server to display. (required)'
-
-      def lookup_compartment_name(compartment_id)
-        compartment = identity_client.get_compartment(compartment_id, {})
-      rescue OCI::Errors::ServiceError => service_error
-        raise unless service_error.service_code == 'NotAuthorizedOrNotFound'
-      else
-        compartment.data.name
-      end
-
-      def lookup_image_name(image_id)
-        image = compute_client.get_image(image_id, {})
-      rescue OCI::Errors::ServiceError => service_error
-        raise unless service_error.service_code == 'NotAuthorizedOrNotFound'
-      else
-        image.data.display_name
-      end
-
-      def lookup_vcn_name(vcn_id)
-        vcn = network_client.get_vcn(vcn_id, {})
-      rescue OCI::Errors::ServiceError => service_error
-        raise unless service_error.service_code == 'NotAuthorizedOrNotFound'
-      else
-        vcn.data.display_name
-      end
-
-      def add_server_details(server, vcn_id)
-        server.extend ServerDetails
-
-        server.launchtime = server.time_created.strftime('%a, %e %b %Y %T %Z')
-        server.compartment_name = lookup_compartment_name(server.compartment_id)
-        server.image_name = lookup_image_name(server.image_id)
-        server.vcn_id = vcn_id
-        server.vcn_name = lookup_vcn_name(vcn_id)
-      end
-
-      def add_vnic_details(vnic)
-        vnic.extend VnicDetails
-
-        begin
-          subnet = network_client.get_subnet(vnic.subnet_id, {})
-        rescue OCI::Errors::ServiceError => service_error
-          raise unless service_error.service_code == 'NotAuthorizedOrNotFound'
-        else
-          vnic.fqdn = vnic.hostname_label + '.' + subnet.data.subnet_domain_name if
-            subnet.data && subnet.data.subnet_domain_name && vnic.hostname_label
-          vnic.subnet_name = subnet.data.display_name if
-            subnet.data && subnet.data.display_name
-          # piggyback the vcn_id from here, so we can avoid a few network calls
-          vnic.vcn_id = subnet.data.vcn_id
-        end
-      end
 
       def run
         validate_required_params(%i[instance_id], config)


### PR DESCRIPTION
This set of changes incorporates the refactoring of the 'server show' output
code into a new helper file, and changes both 'server show' and the out
from 'server create' to use the now separated out code.
