### PR TITLE
Support for ssh connection proxied through a gateway

### DIFF
--- a/lib/chef/knife/oci_server_create.rb
+++ b/lib/chef/knife/oci_server_create.rb
@@ -51,10 +51,6 @@ class Chef
              long: '--metadata METADATA',
              description: 'Custom metadata key/value pairs in JSON format.'
 
-      option :skip_source_dest_check,
-             long: '--skip-source-dest-check',
-             description: 'Set the skipSourceDestCheck flag to be true on the created interface. The VCN will not enforce source and destination address checking.'
-
       option :shape,
              long: '--shape SHAPE',
              description: 'The shape of an instance. The shape determines the number of CPUs, amount of memory, and other resources allocated to the instance. (required)'
@@ -140,8 +136,6 @@ class Chef
         request.create_vnic_details = OCI::Core::Models::CreateVnicDetails.new
         request.create_vnic_details.hostname_label = config[:hostname_label]
         request.create_vnic_details.subnet_id = config[:subnet_id]
-        # not yet supported by SDK
-        # request.create_vnic_details.skip_source_dest_check = config[:skip_source_dest_check] ? true : false
 
         response = compute_client.launch_instance(request)
         instance = response.data

--- a/lib/chef/knife/oci_server_create.rb
+++ b/lib/chef/knife/oci_server_create.rb
@@ -24,6 +24,7 @@ class Chef
 
       deps do
         require 'oci'
+        # we rely on chef to provide net/ssh/gateway
         require 'chef/knife/bootstrap'
         Chef::Knife::Bootstrap.load_deps
       end
@@ -50,6 +51,10 @@ class Chef
              long: '--metadata METADATA',
              description: 'Custom metadata key/value pairs in JSON format.'
 
+      option :skip_source_dest_check,
+             long: '--skip-source-dest-check',
+             description: 'Set the skipSourceDestCheck flag to be true on the created interface. The VCN will not enforce source and destination address checking.'
+
       option :shape,
              long: '--shape SHAPE',
              description: 'The shape of an instance. The shape determines the number of CPUs, amount of memory, and other resources allocated to the instance. (required)'
@@ -65,6 +70,10 @@ class Chef
              long: '--subnet-id SUBNET',
              description: 'The OCID of the subnet. (required)'
 
+      option :use_private_ip,
+             long: '--use-private-ip',
+             description: 'Use private IP address for Chef bootstrap.'
+
       option :user_data_file,
              long: '--user-data-file FILE',
              description: 'A file containing data that Cloud-Init can use to run custom scripts or provide custom Cloud-Init configuration. This parameter is a convenience '\
@@ -76,6 +85,11 @@ class Chef
              long: '--ssh-user USERNAME',
              description: 'The SSH username. Defaults to opc.',
              default: 'opc'
+
+      option :ssh_gateway,
+             short: '-G USERNAME@GATEWAY:PORT',
+             long: '--ssh-gateway USERNAME@GATEWAY:PORT',
+             description: 'The gateway host (and optionally, username and port) to be used for proxying the SSH access to the instance.'
 
       option :ssh_password,
              short: '-P PASSWORD',
@@ -119,11 +133,15 @@ class Chef
         request.availability_domain = config[:availability_domain]
         request.compartment_id = compartment_id
         request.display_name = config[:display_name]
-        request.hostname_label = config[:hostname_label]
         request.image_id = config[:image_id]
         request.metadata = metadata
         request.shape = config[:shape]
-        request.subnet_id = config[:subnet_id]
+
+        request.create_vnic_details = OCI::Core::Models::CreateVnicDetails.new
+        request.create_vnic_details.hostname_label = config[:hostname_label]
+        request.create_vnic_details.subnet_id = config[:subnet_id]
+        # not yet supported by SDK
+        # request.create_vnic_details.skip_source_dest_check = config[:skip_source_dest_check] ? true : false
 
         response = compute_client.launch_instance(request)
         instance = response.data
@@ -133,8 +151,9 @@ class Chef
         ui.msg "Instance '#{instance.display_name}' is now running."
 
         vnic = get_vnic(instance.id, instance.compartment_id)
+        ipaddr = config[:use_private_ip] ? vnic.private_ip : vnic.public_ip
 
-        unless wait_for_ssh(vnic.public_ip, SSH_PORT, WAIT_FOR_SSH_INTERVAL_SECONDS, config[:wait_for_ssh_max])
+        unless wait_for_ssh(ipaddr, SSH_PORT, WAIT_FOR_SSH_INTERVAL_SECONDS, config[:wait_for_ssh_max])
           error_and_exit 'Timed out while waiting for SSH access.'
         end
 
@@ -144,8 +163,7 @@ class Chef
 
         ui.msg "Bootstrapping with node name '#{config[:chef_node_name]}'."
 
-        # TODO: Consider adding a use_private_ip option.
-        bootstrap(vnic.public_ip)
+        bootstrap(ipaddr, config[:ssh_gateway])
 
         ui.msg "Created and bootstrapped node '#{config[:chef_node_name]}'."
         ui.msg "\n"
@@ -156,7 +174,7 @@ class Chef
         display_server_info(config, instance, [vnic])
       end
 
-      def bootstrap(name)
+      def bootstrap(name, ssh_gateway)
         bootstrap = Chef::Knife::Bootstrap.new
 
         bootstrap.name_args = [name]
@@ -165,10 +183,10 @@ class Chef
         bootstrap.config[:ssh_password] = config[:ssh_password]
         bootstrap.config[:identity_file] = config[:identity_file]
         bootstrap.config[:use_sudo] = true
-        bootstrap.config[:ssh_gateway] = config[:ssh_user] + '@' + name
         bootstrap.config[:run_list] = config[:run_list]
-
         bootstrap.config[:yes] = true if config[:yes]
+
+        bootstrap.config[:ssh_gateway] = ssh_gateway if ssh_gateway
 
         bootstrap.run
       end
@@ -187,9 +205,10 @@ class Chef
       end
 
       def wait_to_stabilize
-        # This extra sleep even after getting SSH access is necessary. It's not clear why, but without it we often get
-        # errors about missing a password for ssh, or sometimes errors during bootstrapping. (Note that plugins for other
-        # cloud providers have similar sleeps.)
+        # This extra sleep even after getting SSH access is necessary. It's not clear why,
+        # but without it we often get errors about missing a password for ssh, or sometimes
+        # errors during bootstrapping. (Note that plugins for other cloud providers have
+        # similar sleeps.)
         Kernel.sleep(config[:wait_to_stabilize])
       end
 
@@ -197,10 +216,12 @@ class Chef
         print ui.color('Waiting for ssh access...', :magenta)
 
         end_time = Time.now + max_time_seconds
+        ssh_gateway = config[:ssh_gateway] ? config[:ssh_gateway] : nil
 
         begin
           while Time.now < end_time
-            return true if can_ssh(hostname, ssh_port)
+            can_connect = ssh_gateway ? can_connect_tunneled(ssh_gateway, hostname, ssh_port) : can_connect_direct(hostname, ssh_port)
+            return true if can_connect
 
             show_progress
             sleep interval_seconds
@@ -212,7 +233,44 @@ class Chef
         false
       end
 
-      def can_ssh(hostname, ssh_port)
+      # returns a Net::SSH:Gateway object or nil
+      def get_ssh_gateway(ssh_gateway)
+        # Probably should be doing a more complete lookup here.
+        # For example, looking in ssh configuration files, etc.
+        return nil unless ssh_gateway
+        gw_host, gw_user = ssh_gateway.split('@').reverse
+        gw_host, gw_port = gw_host.split(':')
+        gateway_options = { port: gw_port || SSH_PORT }
+        ssh_gateway_config = Net::SSH::Config.for(gw_host)
+        gw_user ||= ssh_gateway_config[:user]
+
+        # stash a copy of the keys, temporarily
+        gateway_keys = ssh_gateway_config[:keys]
+        # override with user specified keys
+        if config[:ssh_gateway_identity]
+          gateway_keys = Array(config[:ssh_gateway_identity])
+        end
+
+        gateway_options[:keys] = gateway_keys unless gateway_keys.nil?
+
+        Net::SSH::Gateway.new(gw_host, gw_user, gateway_options)
+      end
+
+      def can_connect_tunneled(ssh_gateway, hostname, ssh_port)
+        status = false
+        gateway = get_ssh_gateway(ssh_gateway)
+        gateway.open(hostname, ssh_port) do |local_tunnel_port|
+          status = can_connect_direct('localhost', local_tunnel_port)
+        end
+        status
+      rescue SocketError, IOError, Errno::ETIMEDOUT, Errno::EPERM, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ENETUNREACH, Errno::ECONNRESET, Errno::ENOTCONN
+        false
+      ensure
+        # tear down the gateway, so no tunnel sockets are left connected
+        gateway && gateway.shutdown!
+      end
+
+      def can_connect_direct(hostname, ssh_port)
         socket = TCPSocket.new(hostname, ssh_port)
         # Wait up to 5 seconds.
         readable = IO.select([socket], nil, nil, 5)

--- a/lib/chef/knife/oci_server_create.rb
+++ b/lib/chef/knife/oci_server_create.rb
@@ -240,11 +240,6 @@ class Chef
 
         # stash a copy of the keys, temporarily
         gateway_keys = ssh_gateway_config[:keys]
-        # override with user specified keys
-        if config[:ssh_gateway_identity]
-          gateway_keys = Array(config[:ssh_gateway_identity])
-        end
-
         gateway_options[:keys] = gateway_keys unless gateway_keys.nil?
 
         Net::SSH::Gateway.new(gw_host, gw_user, gateway_options)

--- a/spec/unit/server_create_spec.rb
+++ b/spec/unit/server_create_spec.rb
@@ -186,7 +186,17 @@ describe Chef::Knife::OciServerCreate do
 
   describe 'wait_for_ssh' do
     it 'should return false on timeout' do
-      allow(knife_oci_server_create).to receive(:can_ssh).and_return(false)
+      allow(knife_oci_server_create).to receive(:can_connect_direct).and_return(false)
+      expect(knife_oci_server_create).to receive(:show_progress).at_least(10).times
+      expect(knife_oci_server_create.ui).to receive(:color).once.ordered.with('Waiting for ssh access...', :magenta)
+      expect(knife_oci_server_create.ui).to receive(:color).once.ordered.with("done\n", :magenta)
+      expect(knife_oci_server_create.wait_for_ssh('111.111.111.111', 22, 0.01, 0.5)).to eq(false)
+    end
+
+    it 'should return false on timeout (ssh gateway)' do
+      knife_oci_server_create.config[:ssh_gateway] = 'nobody@111.111.111.11:22'
+      allow(knife_oci_server_create).to receive(:can_connect_tunneled).and_return(false)
+      allow(knife_oci_server_create).to receive(:get_ssh_gateway).and_return(true)
       expect(knife_oci_server_create).to receive(:show_progress).at_least(10).times
       expect(knife_oci_server_create.ui).to receive(:color).once.ordered.with('Waiting for ssh access...', :magenta)
       expect(knife_oci_server_create.ui).to receive(:color).once.ordered.with("done\n", :magenta)
@@ -194,7 +204,17 @@ describe Chef::Knife::OciServerCreate do
     end
 
     it 'should return immediately on success' do
-      allow(knife_oci_server_create).to receive(:can_ssh).and_return(true)
+      allow(knife_oci_server_create).to receive(:can_connect_direct).and_return(true)
+      expect(knife_oci_server_create).to receive(:show_progress).exactly(0).times
+      expect(knife_oci_server_create.ui).to receive(:color).once.ordered.with('Waiting for ssh access...', :magenta)
+      expect(knife_oci_server_create.ui).to receive(:color).once.ordered.with("done\n", :magenta)
+      expect(knife_oci_server_create.wait_for_ssh('111.111.111.111', 22, 0.01, 0.5)).to eq(true)
+    end
+
+    it 'should return immediately on success (ssh gateway)' do
+      knife_oci_server_create.config[:ssh_gateway] = 'nobody@111.111.111.11:22'
+      allow(knife_oci_server_create).to receive(:can_connect_tunneled).and_return(true)
+      allow(knife_oci_server_create).to receive(:get_ssh_gateway).and_return(true)
       expect(knife_oci_server_create).to receive(:show_progress).exactly(0).times
       expect(knife_oci_server_create.ui).to receive(:color).once.ordered.with('Waiting for ssh access...', :magenta)
       expect(knife_oci_server_create.ui).to receive(:color).once.ordered.with("done\n", :magenta)

--- a/test_output/help/server_create.txt
+++ b/test_output/help/server_create.txt
@@ -32,7 +32,6 @@ knife oci server create (options)
         --region REGION              The region to make calls against.  (e.g., `us-ashburn-1`)
     -r, --run-list RUN_LIST          A comma-separated list of roles or recipes.
         --shape SHAPE                The shape of an instance. The shape determines the number of CPUs, amount of memory, and other resources allocated to the instance. (required)
-        --skip-source-dest-check     Set the skipSourceDestCheck flag to be true on the created interface. The VCN will not enforce source and destination address checking.
         --ssh-authorized-keys-file FILE
                                      A file containing one or more public SSH keys to be included in the ~/.ssh/authorized_keys file for the default user on the instance. Use a newline character to separate multiple keys. The SSH keys must be in the format necessary for the authorized_keys file. This parameter is a convenience wrapper around the 'ssh_authorized_keys' field of the --metadata parameter. Populating both values in the same call will result in an error. For more info see documentation: https://docs.us-phoenix-1.oraclecloud.com/api/#/en/iaas/20160918/requests/LaunchInstanceDetails. (required)
     -G USERNAME@GATEWAY:PORT,        The gateway host (and optionally, username and port) to be used for proxying the SSH access to the instance.

--- a/test_output/help/server_create.txt
+++ b/test_output/help/server_create.txt
@@ -32,11 +32,15 @@ knife oci server create (options)
         --region REGION              The region to make calls against.  (e.g., `us-ashburn-1`)
     -r, --run-list RUN_LIST          A comma-separated list of roles or recipes.
         --shape SHAPE                The shape of an instance. The shape determines the number of CPUs, amount of memory, and other resources allocated to the instance. (required)
+        --skip-source-dest-check     Set the skipSourceDestCheck flag to be true on the created interface. The VCN will not enforce source and destination address checking.
         --ssh-authorized-keys-file FILE
                                      A file containing one or more public SSH keys to be included in the ~/.ssh/authorized_keys file for the default user on the instance. Use a newline character to separate multiple keys. The SSH keys must be in the format necessary for the authorized_keys file. This parameter is a convenience wrapper around the 'ssh_authorized_keys' field of the --metadata parameter. Populating both values in the same call will result in an error. For more info see documentation: https://docs.us-phoenix-1.oraclecloud.com/api/#/en/iaas/20160918/requests/LaunchInstanceDetails. (required)
+    -G USERNAME@GATEWAY:PORT,        The gateway host (and optionally, username and port) to be used for proxying the SSH access to the instance.
+        --ssh-gateway
     -P, --ssh-password PASSWORD      The SSH password
     -x, --ssh-user USERNAME          The SSH username. Defaults to opc.
         --subnet-id SUBNET           The OCID of the subnet. (required)
+        --use-private-ip             Use private IP address for Chef bootstrap.
         --user-data-file FILE        A file containing data that Cloud-Init can use to run custom scripts or provide custom Cloud-Init configuration. This parameter is a convenience wrapper around the 'user_data' field of the --metadata parameter.  Populating both values in the same call will result in an error. For more info see Cloud-Init documentation: https://cloudinit.readthedocs.org/en/latest/topics/format.html.
     -V, --verbose                    More verbose output. Use twice for max verbosity
     -v, --version                    Show chef version


### PR DESCRIPTION
Move some vnic options out into the create_vnic_details object
(hostname_label, subnet_id).
Do not generate a ssh gateway by default, but rather only when
the user specifies one on the command line.

Add support for --ssh-gateway commnad line flag.
Add support for --no-public-ip command line flag.
Add --skip_source_dest_check option (still needs SDK support)