### PR TITLE
Fix 'knife oci server create' SSH for newer Chef Workstation versions

### DIFF
--- a/lib/chef/knife/oci_server_create.rb
+++ b/lib/chef/knife/oci_server_create.rb
@@ -165,7 +165,6 @@ class Chef
         bootstrap.config[:ssh_password] = config[:ssh_password]
         bootstrap.config[:identity_file] = config[:identity_file]
         bootstrap.config[:use_sudo] = true
-        bootstrap.config[:ssh_gateway] = config[:ssh_user] + '@' + name
         bootstrap.config[:run_list] = config[:run_list]
 
         bootstrap.config[:yes] = true if config[:yes]


### PR DESCRIPTION
Recent versions of Chef Workstation and ChefDK are failing to SSH into the instance
during 'knife oci server create':

Connecting to x.x.x.x
Enter the password for opc@x.x.x.x:
Failed to authenticate opc - trying password auth
Enter your password:
Enter the password for opc@x.x.x.x:
ERROR: Net::SSH::AuthenticationFailed: Authentication failed for user opc@x.x.x.x

Testing on newer and older versions indicate that this ssh_gateway setting
is not needed.